### PR TITLE
Update installation.rst to include vrep

### DIFF
--- a/docs/source/sas/installation.rst
+++ b/docs/source/sas/installation.rst
@@ -8,7 +8,7 @@ Pre-requisites
 
   sudo add-apt-repository ppa:dqrobotics-dev/development
   sudo apt-get update
-  sudo apt-get install libdqrobotics libdqrobotics-interface-json11 libdqrobotics-interface-coppeliasim libdqrobotics-interface-coppeliasim-zmq
+  sudo apt-get install libdqrobotics libdqrobotics-interface-json11 libdqrobotics-interface-coppeliasim libdqrobotics-interface-coppeliasim-zmq libdqrobotics-interface-vrep
 
 3. `dqrobotics Python devel <https://dqroboticsgithubio.readthedocs.io/en/latest/installation/python.html#installation-development>`_
 


### PR DESCRIPTION
When doing this tutorial using the Humble version of SAS, sas_robot_driver_ros_composer.hpp includes <dqrobotics/interfaces/vrep/DQ_VrepInterface.h> when running colcon build, so it should be included in the prerequisites.

This will make the tutorial applicable for both humble and jazzy