### PR TITLE
Update sas_robot_driver_add_new_robot.rst

### DIFF
--- a/docs/source/sas/sas_robot_driver_add_new_robot.rst
+++ b/docs/source/sas/sas_robot_driver_add_new_robot.rst
@@ -405,7 +405,7 @@ Accessing through Python
 .. literalinclude:: ../../../sas_tutorial_workspace/src/sas_robot_driver_myrobot/scripts/joint_interface_example.py
    :language: python
    :linenos:
-   :lines: 27-
+   :lines: 1, 27-
 
 
 


### PR DESCRIPTION
added line 1 to the display for the Python script so it allows for people to directly copy and paste the code without the error that #!/usr/bin/env not present